### PR TITLE
removed invariant in call for plain functions.

### DIFF
--- a/src/effects/call.js
+++ b/src/effects/call.js
@@ -1,7 +1,6 @@
 import invariant from 'invariant';
 import isFunction from 'lodash/isFunction';
 import { fn as isGeneratorFunction } from 'is-generator';
-import isPromise from 'is-promise';
 
 export const TYPE = '__YIELD_EFFECT_CALL__';
 
@@ -16,8 +15,6 @@ export function processor(effect, { dispatch, effectGeneratorProcessor }) {
     promise = effectGeneratorProcessor(func(...args), { dispatch });
   } else {
     promise = func(...args);
-
-    invariant(isPromise(promise), `"effect.payload.func" must return a promise, but received ${promise}`);
   }
 
   return promise;


### PR DESCRIPTION
I don't believe this invariant is necessary and it would be nice to call regular functions like Redux-Sagas 'call' effect.