### PR TITLE
put returns the result of the dispatch

### DIFF
--- a/src/effects/call.js
+++ b/src/effects/call.js
@@ -14,7 +14,10 @@ export function processor(effect, { dispatch, effectGeneratorProcessor }) {
     // func is an effect generator
     promise = effectGeneratorProcessor(func(...args), { dispatch });
   } else {
-    promise = Promise.resolve().then(() => func(...args));
+    promise = func(...args);
+    if (!promise.then) {
+      promise = Promise.resolve(promise);
+    }
   }
 
   return promise;

--- a/src/effects/put.js
+++ b/src/effects/put.js
@@ -8,9 +8,7 @@ export function processor(effect, { dispatch }) {
 
   invariant(isPlainObject(action), `"put" only supports dispatching plain object actions, but received ${action}`);
 
-  return Promise.resolve().then(() => {
-    dispatch(action);
-  });
+  return Promise.resolve().then(() => dispatch(action));
 }
 
 export default function put(action) {

--- a/src/effects/put.spec.js
+++ b/src/effects/put.spec.js
@@ -1,0 +1,36 @@
+import put, { TYPE } from './put';
+
+const actionCreator = () => ({
+  type: 'SAMPLE',
+  a: 1,
+});
+
+describe('put', () => {
+  describe('effect creator', () => {
+    it('should return correct `effect` object', () => {
+      const action = actionCreator();
+      expect(put(action)).toEqual({
+        type: TYPE,
+        payload: {
+          action,
+        },
+      });
+    });
+
+    it('should throw exception if `action` argument is not a object', () => {
+      const notAction = 'I am not an action';
+
+      expect(() => put(notAction)).toThrowError(/only supports dispatching plain objects/);
+    });
+  });
+
+  // TODO: create a test for the effect processor.
+  describe('effect processor', () => {
+    // it('should dispatch the action passed to it', () => {
+    // });
+    // it('should return any value a middleware returned for dispatching the action', () => {
+    // Jason: This well be important for another library I created and well upload later.
+    // });
+  });
+});
+


### PR DESCRIPTION
I needed the return of the put effect, because my middleware returns a selector if meta.selector is defined.

This seemed like an obvious addition that would only improve the library.

On top of that, I realized I neglected to update the src code last time. I'm not sure what parameters you use to compile the code, but I simply manually edited the src files to be correct.